### PR TITLE
docs: Add conda and uv installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Diffly is a Python package for comparing [Polars](https://pola.rs/) DataFrames w
 
 ## 💿 Installation
 
-You can install `diffly` using your favorite package manager, e.g., `pixi` or `pip`:
+You can install `diffly` using your favorite package manager:
 
 ```bash
 pixi add diffly
+conda install diffly
+uv add diffly
 pip install diffly
 ```
 


### PR DESCRIPTION
## Summary
- Adds `conda install` and `uv add` as installation options in the README alongside the existing `pixi add` and `pip install` methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)