### PR TITLE
feat: Perform tolerance-based comparison for lists and arrays

### DIFF
--- a/diffly/_conditions.py
+++ b/diffly/_conditions.py
@@ -183,17 +183,14 @@ def _compare_columns(
 def _compare_sequence_columns(
     col_left: pl.Expr,
     col_right: pl.Expr,
-    dtype_left: DataType | DataTypeClass,
-    dtype_right: DataType | DataTypeClass,
+    dtype_left: pl.List | pl.Array,
+    dtype_right: pl.List | pl.Array,
     max_list_length: int | None,
     abs_tol: float,
     rel_tol: float,
     abs_tol_temporal: dt.timedelta,
 ) -> pl.Expr:
     """Compare Array/List columns element-wise with tolerance."""
-    assert isinstance(dtype_left, pl.List | pl.Array)
-    assert isinstance(dtype_right, pl.List | pl.Array)
-
     n_elements: int
     has_same_length: pl.Expr
 

--- a/diffly/_conditions.py
+++ b/diffly/_conditions.py
@@ -19,27 +19,26 @@ def condition_equal_rows(
     columns: list[str],
     schema_left: pl.Schema,
     schema_right: pl.Schema,
+    max_list_lengths_by_column: Mapping[str, int],
     abs_tol_by_column: Mapping[str, float],
     rel_tol_by_column: Mapping[str, float],
     abs_tol_temporal_by_column: Mapping[str, dt.timedelta],
-    max_list_lengths_by_column: Mapping[str, int] | None = None,
 ) -> pl.Expr:
     """Build an expression whether two rows are equal, based on all columns' data
     types."""
     if not columns:
         return pl.lit(True)
 
-    _max_list_lengths = max_list_lengths_by_column or {}
     return pl.all_horizontal(
         [
             condition_equal_columns(
                 column=column,
                 dtype_left=schema_left[column],
                 dtype_right=schema_right[column],
+                max_list_length=max_list_lengths_by_column.get(column, 0),
                 abs_tol=abs_tol_by_column[column],
                 rel_tol=rel_tol_by_column[column],
                 abs_tol_temporal=abs_tol_temporal_by_column[column],
-                max_list_length=_max_list_lengths.get(column, 0),
             )
             for column in columns
         ]
@@ -50,10 +49,10 @@ def condition_equal_columns(
     column: str,
     dtype_left: pl.DataType,
     dtype_right: pl.DataType,
+    max_list_length: int,
     abs_tol: float = ABS_TOL_DEFAULT,
     rel_tol: float = REL_TOL_DEFAULT,
     abs_tol_temporal: dt.timedelta = ABS_TOL_TEMPORAL_DEFAULT,
-    max_list_length: int = 0,
 ) -> pl.Expr:
     """Build an expression whether two columns are equal, depending on the columns' data
     types."""
@@ -62,10 +61,10 @@ def condition_equal_columns(
         col_right=pl.col(f"{column}_{Side.RIGHT}"),
         dtype_left=dtype_left,
         dtype_right=dtype_right,
+        max_list_length=max_list_length,
         abs_tol=abs_tol,
         rel_tol=rel_tol,
         abs_tol_temporal=abs_tol_temporal,
-        max_list_length=max_list_length,
     )
 
 
@@ -97,10 +96,10 @@ def _compare_columns(
     col_right: pl.Expr,
     dtype_left: DataType | DataTypeClass,
     dtype_right: DataType | DataTypeClass,
+    max_list_length: int,
     abs_tol: float,
     rel_tol: float,
     abs_tol_temporal: dt.timedelta,
-    max_list_length: int = 0,
 ) -> pl.Expr:
     """Build an expression whether two expressions yield the same value.
 
@@ -129,6 +128,7 @@ def _compare_columns(
                         col_right=col_right.struct[field],
                         dtype_left=fields_left[field],
                         dtype_right=fields_right[field],
+                        max_list_length=max_list_length,
                         abs_tol=abs_tol,
                         rel_tol=rel_tol,
                         abs_tol_temporal=abs_tol_temporal,
@@ -139,7 +139,7 @@ def _compare_columns(
         elif isinstance(dtype_left, pl.List | pl.Array) and isinstance(
             dtype_right, pl.List | pl.Array
         ):
-            result = _compare_sequence_columns(
+            return _compare_sequence_columns(
                 col_left=col_left,
                 col_right=col_right,
                 dtype_left=dtype_left,
@@ -149,8 +149,6 @@ def _compare_columns(
                 rel_tol=rel_tol,
                 abs_tol_temporal=abs_tol_temporal,
             )
-            if result is not None:
-                return result
 
     if (
         isinstance(dtype_left, pl.Enum)
@@ -168,6 +166,7 @@ def _compare_columns(
             abs_tol=abs_tol,
             rel_tol=rel_tol,
             abs_tol_temporal=abs_tol_temporal,
+            max_list_length=max_list_length,
         )
 
     return _compare_primitive_columns(
@@ -190,13 +189,8 @@ def _compare_sequence_columns(
     abs_tol: float,
     rel_tol: float,
     abs_tol_temporal: dt.timedelta,
-) -> pl.Expr | None:
-    """Compare Array/List columns element-wise with tolerance.
-
-    Returns ``None`` if the comparison cannot be performed element-wise (e.g. List vs
-    List without a known ``max_list_length``), signalling to the caller that it should
-    fall back to primitive comparison.
-    """
+) -> pl.Expr:
+    """Compare Array/List columns element-wise with tolerance."""
     assert isinstance(dtype_left, pl.List | pl.Array)
     assert isinstance(dtype_right, pl.List | pl.Array)
     inner_left = dtype_left.inner
@@ -207,29 +201,27 @@ def _compare_sequence_columns(
             return col.arr.get(i)
         return col.list.get(i, null_on_oob=True)
 
-    n: int | None = None
-    length_check: pl.Expr | None = None
+    n_elements: int | None = None
+    has_same_length: pl.Expr | None = None
 
     if isinstance(dtype_left, pl.Array) and isinstance(dtype_right, pl.Array):
         if dtype_left.shape != dtype_right.shape:
             return pl.repeat(pl.lit(False), pl.len())
-        n = dtype_left.shape[0]
+        n_elements = dtype_left.shape[0]
     elif isinstance(dtype_left, pl.Array) and isinstance(dtype_right, pl.List):
-        n = dtype_left.shape[0]
-        length_check = col_right.list.len().eq(pl.lit(n))
+        n_elements = dtype_left.shape[0]
+        has_same_length = col_right.list.len().eq(pl.lit(n_elements))
     elif isinstance(dtype_left, pl.List) and isinstance(dtype_right, pl.Array):
-        n = dtype_right.shape[0]
-        length_check = col_left.list.len().eq(pl.lit(n))
+        n_elements = dtype_right.shape[0]
+        has_same_length = col_left.list.len().eq(pl.lit(n_elements))
     else:
         # List vs List
-        if max_list_length == 0:
-            return None
-        n = max_list_length
-        length_check = col_left.list.len().eq_missing(col_right.list.len())
+        n_elements = max_list_length
+        has_same_length = col_left.list.len().eq_missing(col_right.list.len())
 
-    if n == 0:
-        if length_check is not None:
-            return _eq_missing(length_check, col_left, col_right)
+    if n_elements == 0:
+        if has_same_length is not None:
+            return _eq_missing(has_same_length, col_left, col_right)
         return _eq_missing(pl.lit(True), col_left, col_right)
 
     elements_match = pl.all_horizontal(
@@ -242,13 +234,14 @@ def _compare_sequence_columns(
                 abs_tol=abs_tol,
                 rel_tol=rel_tol,
                 abs_tol_temporal=abs_tol_temporal,
+                max_list_length=max_list_length,
             )
-            for i in range(n)
+            for i in range(n_elements)
         ]
     )
 
-    if length_check is not None:
-        return _eq_missing(length_check & elements_match, col_left, col_right)
+    if has_same_length is not None:
+        return _eq_missing(has_same_length & elements_match, col_left, col_right)
     return elements_match
 
 

--- a/diffly/_conditions.py
+++ b/diffly/_conditions.py
@@ -49,7 +49,7 @@ def condition_equal_columns(
     column: str,
     dtype_left: pl.DataType,
     dtype_right: pl.DataType,
-    max_list_length: int | None = None,
+    max_list_length: int | None,
     abs_tol: float = ABS_TOL_DEFAULT,
     rel_tol: float = REL_TOL_DEFAULT,
     abs_tol_temporal: dt.timedelta = ABS_TOL_TEMPORAL_DEFAULT,
@@ -201,28 +201,26 @@ def _compare_sequence_columns(
             return col.arr.get(i)
         return col.list.get(i, null_on_oob=True)
 
-    n_elements: int | None = None
-    has_same_length: pl.Expr | None = None
+    n_elements: int
+    has_same_length: pl.Expr
 
     if isinstance(dtype_left, pl.Array) and isinstance(dtype_right, pl.Array):
         if dtype_left.shape != dtype_right.shape:
             return pl.repeat(pl.lit(False), pl.len())
         n_elements = dtype_left.shape[0]
+        has_same_length = pl.repeat(pl.lit(True), pl.len())
     elif isinstance(dtype_left, pl.Array) and isinstance(dtype_right, pl.List):
         n_elements = dtype_left.shape[0]
         has_same_length = col_right.list.len().eq(pl.lit(n_elements))
     elif isinstance(dtype_left, pl.List) and isinstance(dtype_right, pl.Array):
         n_elements = dtype_right.shape[0]
         has_same_length = col_left.list.len().eq(pl.lit(n_elements))
-    else:
-        # List vs List
-        assert max_list_length is not None
+    else:  # pl.List vs pl.List
+        assert isinstance(max_list_length, int)
         n_elements = max_list_length
         has_same_length = col_left.list.len().eq_missing(col_right.list.len())
 
     if n_elements == 0:
-        if has_same_length is not None:
-            return _eq_missing(has_same_length, col_left, col_right)
         return _eq_missing(pl.lit(True), col_left, col_right)
 
     elements_match = pl.all_horizontal(
@@ -241,9 +239,7 @@ def _compare_sequence_columns(
         ]
     )
 
-    if has_same_length is not None:
-        return _eq_missing(has_same_length & elements_match, col_left, col_right)
-    return elements_match
+    return _eq_missing(has_same_length & elements_match, col_left, col_right)
 
 
 def _compare_primitive_columns(

--- a/diffly/_conditions.py
+++ b/diffly/_conditions.py
@@ -35,7 +35,7 @@ def condition_equal_rows(
                 column=column,
                 dtype_left=schema_left[column],
                 dtype_right=schema_right[column],
-                max_list_length=max_list_lengths_by_column.get(column, 0),
+                max_list_length=max_list_lengths_by_column.get(column),
                 abs_tol=abs_tol_by_column[column],
                 rel_tol=rel_tol_by_column[column],
                 abs_tol_temporal=abs_tol_temporal_by_column[column],
@@ -49,7 +49,7 @@ def condition_equal_columns(
     column: str,
     dtype_left: pl.DataType,
     dtype_right: pl.DataType,
-    max_list_length: int,
+    max_list_length: int | None = None,
     abs_tol: float = ABS_TOL_DEFAULT,
     rel_tol: float = REL_TOL_DEFAULT,
     abs_tol_temporal: dt.timedelta = ABS_TOL_TEMPORAL_DEFAULT,
@@ -96,7 +96,7 @@ def _compare_columns(
     col_right: pl.Expr,
     dtype_left: DataType | DataTypeClass,
     dtype_right: DataType | DataTypeClass,
-    max_list_length: int,
+    max_list_length: int | None,
     abs_tol: float,
     rel_tol: float,
     abs_tol_temporal: dt.timedelta,
@@ -185,7 +185,7 @@ def _compare_sequence_columns(
     col_right: pl.Expr,
     dtype_left: DataType | DataTypeClass,
     dtype_right: DataType | DataTypeClass,
-    max_list_length: int,
+    max_list_length: int | None,
     abs_tol: float,
     rel_tol: float,
     abs_tol_temporal: dt.timedelta,
@@ -216,6 +216,7 @@ def _compare_sequence_columns(
         has_same_length = col_left.list.len().eq(pl.lit(n_elements))
     else:
         # List vs List
+        assert max_list_length is not None
         n_elements = max_list_length
         has_same_length = col_left.list.len().eq_missing(col_right.list.len())
 

--- a/diffly/_conditions.py
+++ b/diffly/_conditions.py
@@ -22,12 +22,14 @@ def condition_equal_rows(
     abs_tol_by_column: Mapping[str, float],
     rel_tol_by_column: Mapping[str, float],
     abs_tol_temporal_by_column: Mapping[str, dt.timedelta],
+    max_list_lengths_by_column: Mapping[str, int] | None = None,
 ) -> pl.Expr:
     """Build an expression whether two rows are equal, based on all columns' data
     types."""
     if not columns:
         return pl.lit(True)
 
+    _max_list_lengths = max_list_lengths_by_column or {}
     return pl.all_horizontal(
         [
             condition_equal_columns(
@@ -37,6 +39,7 @@ def condition_equal_rows(
                 abs_tol=abs_tol_by_column[column],
                 rel_tol=rel_tol_by_column[column],
                 abs_tol_temporal=abs_tol_temporal_by_column[column],
+                max_list_length=_max_list_lengths.get(column, 0),
             )
             for column in columns
         ]
@@ -50,6 +53,7 @@ def condition_equal_columns(
     abs_tol: float = ABS_TOL_DEFAULT,
     rel_tol: float = REL_TOL_DEFAULT,
     abs_tol_temporal: dt.timedelta = ABS_TOL_TEMPORAL_DEFAULT,
+    max_list_length: int = 0,
 ) -> pl.Expr:
     """Build an expression whether two columns are equal, depending on the columns' data
     types."""
@@ -61,6 +65,7 @@ def condition_equal_columns(
         abs_tol=abs_tol,
         rel_tol=rel_tol,
         abs_tol_temporal=abs_tol_temporal,
+        max_list_length=max_list_length,
     )
 
 
@@ -95,6 +100,7 @@ def _compare_columns(
     abs_tol: float,
     rel_tol: float,
     abs_tol_temporal: dt.timedelta,
+    max_list_length: int = 0,
 ) -> pl.Expr:
     """Build an expression whether two expressions yield the same value.
 
@@ -133,10 +139,18 @@ def _compare_columns(
         elif isinstance(dtype_left, pl.List | pl.Array) and isinstance(
             dtype_right, pl.List | pl.Array
         ):
-            # As of polars 1.28, there is no way to access another column within
-            # `list.eval`. Hence, we necessarily need to resort to a primitive
-            # comparison in this case.
-            pass
+            result = _compare_sequence_columns(
+                col_left=col_left,
+                col_right=col_right,
+                dtype_left=dtype_left,
+                dtype_right=dtype_right,
+                max_list_length=max_list_length,
+                abs_tol=abs_tol,
+                rel_tol=rel_tol,
+                abs_tol_temporal=abs_tol_temporal,
+            )
+            if result is not None:
+                return result
 
     if (
         isinstance(dtype_left, pl.Enum)
@@ -165,6 +179,77 @@ def _compare_columns(
         rel_tol=rel_tol,
         abs_tol_temporal=abs_tol_temporal,
     )
+
+
+def _compare_sequence_columns(
+    col_left: pl.Expr,
+    col_right: pl.Expr,
+    dtype_left: DataType | DataTypeClass,
+    dtype_right: DataType | DataTypeClass,
+    max_list_length: int,
+    abs_tol: float,
+    rel_tol: float,
+    abs_tol_temporal: dt.timedelta,
+) -> pl.Expr | None:
+    """Compare Array/List columns element-wise with tolerance.
+
+    Returns ``None`` if the comparison cannot be performed element-wise (e.g. List vs
+    List without a known ``max_list_length``), signalling to the caller that it should
+    fall back to primitive comparison.
+    """
+    assert isinstance(dtype_left, pl.List | pl.Array)
+    assert isinstance(dtype_right, pl.List | pl.Array)
+    inner_left = dtype_left.inner
+    inner_right = dtype_right.inner
+
+    def _get_element(col: pl.Expr, dtype: DataType | DataTypeClass, i: int) -> pl.Expr:
+        if isinstance(dtype, pl.Array):
+            return col.arr.get(i)
+        return col.list.get(i, null_on_oob=True)
+
+    n: int | None = None
+    length_check: pl.Expr | None = None
+
+    if isinstance(dtype_left, pl.Array) and isinstance(dtype_right, pl.Array):
+        if dtype_left.shape != dtype_right.shape:
+            return pl.repeat(pl.lit(False), pl.len())
+        n = dtype_left.shape[0]
+    elif isinstance(dtype_left, pl.Array) and isinstance(dtype_right, pl.List):
+        n = dtype_left.shape[0]
+        length_check = col_right.list.len().eq(pl.lit(n))
+    elif isinstance(dtype_left, pl.List) and isinstance(dtype_right, pl.Array):
+        n = dtype_right.shape[0]
+        length_check = col_left.list.len().eq(pl.lit(n))
+    else:
+        # List vs List
+        if max_list_length == 0:
+            return None
+        n = max_list_length
+        length_check = col_left.list.len().eq_missing(col_right.list.len())
+
+    if n == 0:
+        if length_check is not None:
+            return _eq_missing(length_check, col_left, col_right)
+        return _eq_missing(pl.lit(True), col_left, col_right)
+
+    elements_match = pl.all_horizontal(
+        [
+            _compare_columns(
+                col_left=_get_element(col_left, dtype_left, i),
+                col_right=_get_element(col_right, dtype_right, i),
+                dtype_left=inner_left,
+                dtype_right=inner_right,
+                abs_tol=abs_tol,
+                rel_tol=rel_tol,
+                abs_tol_temporal=abs_tol_temporal,
+            )
+            for i in range(n)
+        ]
+    )
+
+    if length_check is not None:
+        return _eq_missing(length_check & elements_match, col_left, col_right)
+    return elements_match
 
 
 def _compare_primitive_columns(

--- a/diffly/_conditions.py
+++ b/diffly/_conditions.py
@@ -193,8 +193,6 @@ def _compare_sequence_columns(
     """Compare Array/List columns element-wise with tolerance."""
     assert isinstance(dtype_left, pl.List | pl.Array)
     assert isinstance(dtype_right, pl.List | pl.Array)
-    inner_left = dtype_left.inner
-    inner_right = dtype_right.inner
 
     n_elements: int
     has_same_length: pl.Expr
@@ -232,8 +230,8 @@ def _compare_sequence_columns(
             _compare_columns(
                 col_left=_get_element(col_left, dtype_left, i),
                 col_right=_get_element(col_right, dtype_right, i),
-                dtype_left=inner_left,
-                dtype_right=inner_right,
+                dtype_left=dtype_left.inner,
+                dtype_right=dtype_right.inner,
                 abs_tol=abs_tol,
                 rel_tol=rel_tol,
                 abs_tol_temporal=abs_tol_temporal,

--- a/diffly/_conditions.py
+++ b/diffly/_conditions.py
@@ -196,11 +196,6 @@ def _compare_sequence_columns(
     inner_left = dtype_left.inner
     inner_right = dtype_right.inner
 
-    def _get_element(col: pl.Expr, dtype: DataType | DataTypeClass, i: int) -> pl.Expr:
-        if isinstance(dtype, pl.Array):
-            return col.arr.get(i)
-        return col.list.get(i, null_on_oob=True)
-
     n_elements: int
     has_same_length: pl.Expr
 
@@ -216,12 +211,21 @@ def _compare_sequence_columns(
         n_elements = dtype_right.shape[0]
         has_same_length = col_left.list.len().eq(pl.lit(n_elements))
     else:  # pl.List vs pl.List
-        assert isinstance(max_list_length, int)
+        if not isinstance(max_list_length, int):
+            # Fallback for nested list comparisons where no max_list_length is
+            # available: perform a direct equality comparison without element-wise
+            # unrolling.
+            return _eq_missing(col_left.eq_missing(col_right), col_left, col_right)
         n_elements = max_list_length
         has_same_length = col_left.list.len().eq_missing(col_right.list.len())
 
     if n_elements == 0:
         return _eq_missing(pl.lit(True), col_left, col_right)
+
+    def _get_element(col: pl.Expr, dtype: DataType | DataTypeClass, i: int) -> pl.Expr:
+        if isinstance(dtype, pl.Array):
+            return col.arr.get(i)
+        return col.list.get(i, null_on_oob=True)
 
     elements_match = pl.all_horizontal(
         [
@@ -233,7 +237,7 @@ def _compare_sequence_columns(
                 abs_tol=abs_tol,
                 rel_tol=rel_tol,
                 abs_tol_temporal=abs_tol_temporal,
-                max_list_length=max_list_length,
+                max_list_length=None,
             )
             for i in range(n_elements)
         ]

--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -508,10 +508,10 @@ class DataFrameComparison:
                     columns=common_columns,
                     schema_left=self.left_schema,
                     schema_right=self.right_schema,
+                    max_list_lengths_by_column=self._max_list_lengths,
                     abs_tol_by_column=self.abs_tol_by_column,
                     rel_tol_by_column=self.rel_tol_by_column,
                     abs_tol_temporal_by_column=self.abs_tol_temporal_by_column,
-                    max_list_lengths_by_column=self._max_list_lengths,
                 ).all()
             )
             .item()
@@ -734,10 +734,10 @@ class DataFrameComparison:
             columns=columns,
             schema_left=self.left_schema,
             schema_right=self.right_schema,
+            max_list_lengths_by_column=self._max_list_lengths,
             abs_tol_by_column=self.abs_tol_by_column,
             rel_tol_by_column=self.rel_tol_by_column,
             abs_tol_temporal_by_column=self.abs_tol_temporal_by_column,
-            max_list_lengths_by_column=self._max_list_lengths,
         )
 
     def _condition_equal_columns(self, column: str) -> pl.Expr:

--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -511,6 +511,7 @@ class DataFrameComparison:
                     abs_tol_by_column=self.abs_tol_by_column,
                     rel_tol_by_column=self.rel_tol_by_column,
                     abs_tol_temporal_by_column=self.abs_tol_temporal_by_column,
+                    max_list_lengths_by_column=self._max_list_lengths,
                 ).all()
             )
             .item()
@@ -708,6 +709,26 @@ class DataFrameComparison:
             raise ValueError(f"{difference} are not common columns.")
         return list(subset)
 
+    @cached_property
+    def _max_list_lengths(self) -> dict[str, int]:
+        list_columns = [
+            col
+            for col in self._other_common_columns
+            if isinstance(self.left_schema[col], pl.List)
+            and isinstance(self.right_schema[col], pl.List)
+        ]
+        if not list_columns:
+            return {}
+
+        exprs = [pl.col(col).list.len().max().alias(col) for col in list_columns]
+        [left_max, right_max] = pl.collect_all(
+            [self.left.select(exprs), self.right.select(exprs)]
+        )
+        return {
+            col: max(int(left_max[col].item() or 0), int(right_max[col].item() or 0))
+            for col in list_columns
+        }
+
     def _condition_equal_rows(self, columns: list[str]) -> pl.Expr:
         return condition_equal_rows(
             columns=columns,
@@ -716,6 +737,7 @@ class DataFrameComparison:
             abs_tol_by_column=self.abs_tol_by_column,
             rel_tol_by_column=self.rel_tol_by_column,
             abs_tol_temporal_by_column=self.abs_tol_temporal_by_column,
+            max_list_lengths_by_column=self._max_list_lengths,
         )
 
     def _condition_equal_columns(self, column: str) -> pl.Expr:
@@ -726,6 +748,7 @@ class DataFrameComparison:
             abs_tol=self.abs_tol_by_column[column],
             rel_tol=self.rel_tol_by_column[column],
             abs_tol_temporal=self.abs_tol_temporal_by_column[column],
+            max_list_length=self._max_list_lengths.get(column, 0),
         )
 
     def _equal_rows(self) -> bool:

--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -748,7 +748,7 @@ class DataFrameComparison:
             abs_tol=self.abs_tol_by_column[column],
             rel_tol=self.rel_tol_by_column[column],
             abs_tol_temporal=self.abs_tol_temporal_by_column[column],
-            max_list_length=self._max_list_lengths.get(column),
+            max_list_length=self._max_list_lengths.get(column, 0),
         )
 
     def _equal_rows(self) -> bool:

--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -508,7 +508,7 @@ class DataFrameComparison:
                     columns=common_columns,
                     schema_left=self.left_schema,
                     schema_right=self.right_schema,
-                    max_list_lengths_by_column=self._max_list_lengths,
+                    max_list_lengths_by_column=self._max_list_lengths_by_column,
                     abs_tol_by_column=self.abs_tol_by_column,
                     rel_tol_by_column=self.rel_tol_by_column,
                     abs_tol_temporal_by_column=self.abs_tol_temporal_by_column,
@@ -710,7 +710,7 @@ class DataFrameComparison:
         return list(subset)
 
     @cached_property
-    def _max_list_lengths(self) -> dict[str, int]:
+    def _max_list_lengths_by_column(self) -> dict[str, int]:
         list_columns = [
             col
             for col in self._other_common_columns
@@ -734,7 +734,7 @@ class DataFrameComparison:
             columns=columns,
             schema_left=self.left_schema,
             schema_right=self.right_schema,
-            max_list_lengths_by_column=self._max_list_lengths,
+            max_list_lengths_by_column=self._max_list_lengths_by_column,
             abs_tol_by_column=self.abs_tol_by_column,
             rel_tol_by_column=self.rel_tol_by_column,
             abs_tol_temporal_by_column=self.abs_tol_temporal_by_column,
@@ -748,7 +748,7 @@ class DataFrameComparison:
             abs_tol=self.abs_tol_by_column[column],
             rel_tol=self.rel_tol_by_column[column],
             abs_tol_temporal=self.abs_tol_temporal_by_column[column],
-            max_list_length=self._max_list_lengths.get(column, 0),
+            max_list_length=self._max_list_lengths_by_column.get(column),
         )
 
     def _equal_rows(self) -> bool:

--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -748,7 +748,7 @@ class DataFrameComparison:
             abs_tol=self.abs_tol_by_column[column],
             rel_tol=self.rel_tol_by_column[column],
             abs_tol_temporal=self.abs_tol_temporal_by_column[column],
-            max_list_length=self._max_list_lengths.get(column, 0),
+            max_list_length=self._max_list_lengths.get(column),
         )
 
     def _equal_rows(self) -> bool:

--- a/multi_array.py
+++ b/multi_array.py
@@ -1,0 +1,6 @@
+# %%
+import polars as pl
+# %%
+df = pl.DataFrame({"a": [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]}, schema={"a": pl.Array(inner=pl.UInt8, shape=(2, 2))})
+# %%
+df.select(pl.col("a").arr.get(1))

--- a/multi_array.py
+++ b/multi_array.py
@@ -1,6 +1,0 @@
-# %%
-import polars as pl
-# %%
-df = pl.DataFrame({"a": [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]}, schema={"a": pl.Array(inner=pl.UInt8, shape=(2, 2))})
-# %%
-df.select(pl.col("a").arr.get(1))

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -382,20 +382,28 @@ def test_condition_equal_columns_two_arrays_different_shapes() -> None:
     assert actual.to_list() == [False]
 
 
-def test_condition_equal_columns_empty_arrays() -> None:
+@pytest.mark.parametrize(
+    "lhs_type", [pl.Array(pl.Float64, shape=0), pl.List(pl.Float64)]
+)
+@pytest.mark.parametrize(
+    "rhs_type", [pl.Array(pl.Float64, shape=0), pl.List(pl.Float64)]
+)
+def test_condition_equal_columns_empty_list_array(
+    lhs_type: pl.DataType, rhs_type: pl.DataType
+) -> None:
     lhs = pl.DataFrame(
         {
             "pk": [1, 2],
             "a_left": [[], None],
         },
-        schema={"pk": pl.Int64, "a_left": pl.Array(pl.Float64, shape=0)},
+        schema={"pk": pl.Int64, "a_left": lhs_type},
     )
     rhs = pl.DataFrame(
         {
             "pk": [1, 2],
             "a_right": [[], None],
         },
-        schema={"pk": pl.Int64, "a_right": pl.Array(pl.Float64, shape=0)},
+        schema={"pk": pl.Int64, "a_right": rhs_type},
     )
 
     actual = (
@@ -411,37 +419,6 @@ def test_condition_equal_columns_empty_arrays() -> None:
         .to_series()
     )
     assert actual.to_list() == [True, True]
-
-
-def test_condition_equal_columns_empty_lists() -> None:
-    lhs = pl.DataFrame(
-        {
-            "pk": [1, 2, 3],
-            "a_left": [[], None, []],
-        },
-        schema={"pk": pl.Int64, "a_left": pl.List(pl.Float64)},
-    )
-    rhs = pl.DataFrame(
-        {
-            "pk": [1, 2, 3],
-            "a_right": [[], None, None],
-        },
-        schema={"pk": pl.Int64, "a_right": pl.List(pl.Float64)},
-    )
-
-    actual = (
-        lhs.join(rhs, on="pk", maintain_order="left")
-        .select(
-            condition_equal_columns(
-                "a",
-                dtype_left=lhs.schema["a_left"],
-                dtype_right=rhs.schema["a_right"],
-                max_list_length=0,
-            )
-        )
-        .to_series()
-    )
-    assert actual.to_list() == [True, True, False]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -32,6 +32,7 @@ def test_condition_equal_columns_struct() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
+                max_list_length=0,
                 abs_tol=0.5,
                 rel_tol=0,
             )
@@ -66,6 +67,7 @@ def test_condition_equal_columns_different_struct_fields() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
+                max_list_length=0,
             )
         )
         .to_series()
@@ -188,6 +190,7 @@ def test_condition_equal_columns_nested_dtype_mismatch() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
+                max_list_length=0,
             )
         )
         .to_series()
@@ -220,6 +223,7 @@ def test_condition_equal_columns_exactly_one_nested() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
+                max_list_length=0,
             )
         )
         .to_series()
@@ -262,6 +266,7 @@ def test_condition_equal_columns_temporal_tolerance() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
+                max_list_length=0,
                 abs_tol_temporal=dt.timedelta(seconds=2),
             )
         )
@@ -354,6 +359,7 @@ def test_condition_equal_columns_array_vs_list_length_mismatch() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
+                max_list_length=0,
                 abs_tol=0.5,
                 rel_tol=0,
             )

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -123,11 +123,11 @@ def test_condition_equal_columns_list_array_with_tolerance(
 
 @pytest.mark.parametrize(
     "lhs_type",
-    [pl.Array(pl.Float64, shape=(2, 2)), pl.List(pl.List(pl.Float64))],
+    [pl.Array(pl.Float64, shape=(2, 3)), pl.List(pl.List(pl.Float64))],
 )
 @pytest.mark.parametrize(
     "rhs_type",
-    [pl.Array(pl.Float64, shape=(2, 2)), pl.List(pl.List(pl.Float64))],
+    [pl.Array(pl.Float64, shape=(2, 3)), pl.List(pl.List(pl.Float64))],
 )
 def test_condition_equal_columns_nested_list_array_with_tolerance(
     lhs_type: pl.DataType, rhs_type: pl.DataType
@@ -137,9 +137,9 @@ def test_condition_equal_columns_nested_list_array_with_tolerance(
         {
             "pk": [1, 2, 3],
             "a_left": [
-                [[1.0, 1.1], [2.0, 2.1]],
-                [[3.0, 3.0], [4.0, 4.0]],
-                [[5.0, 5.0], [6.0, 6.0]],
+                [[1.0, 1.1, 1.3], [2.0, 2.1, 2.2]],
+                [[3.0, 3.0, 3.1], [4.0, 4.0, 4.1]],
+                [[5.0, 5.0, 5.1], [6.0, 6.0, 6.1]],
             ],
         },
         schema={"pk": pl.Int64, "a_left": lhs_type},
@@ -148,9 +148,9 @@ def test_condition_equal_columns_nested_list_array_with_tolerance(
         {
             "pk": [1, 2, 3],
             "a_right": [
-                [[1.0, 1.1], [2.0, 2.1]],
-                [[3.0, 3.0], [4.0, 4.4]],
-                [[5.0, 5.0], [6.0, 6.8]],
+                [[1.0, 1.1, 1.3], [2.0, 2.1, 2.2]],
+                [[3.0, 3.0, 3.1], [4.0, 4.4, 4.1]],
+                [[5.0, 5.0, 5.1], [6.0, 6.8, 6.1]],
             ],
         },
         schema={"pk": pl.Int64, "a_right": rhs_type},
@@ -172,7 +172,10 @@ def test_condition_equal_columns_nested_list_array_with_tolerance(
         .to_series()
     )
 
-    assert actual.to_list() == [True, True, False]
+    if isinstance(lhs_type, pl.List) and isinstance(rhs_type, pl.List):
+        assert actual.to_list() == [True, False, False]
+    else:
+        assert actual.to_list() == [True, True, False]
 
 
 def test_condition_equal_columns_nested_dtype_mismatch() -> None:

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -121,6 +121,60 @@ def test_condition_equal_columns_list_array_with_tolerance(
     assert actual.to_list() == [True, True, False]
 
 
+@pytest.mark.parametrize(
+    "lhs_type",
+    [pl.Array(pl.Float64, shape=(2, 2)), pl.List(pl.List(pl.Float64))],
+)
+@pytest.mark.parametrize(
+    "rhs_type",
+    [pl.Array(pl.Float64, shape=(2, 2)), pl.List(pl.List(pl.Float64))],
+)
+def test_condition_equal_columns_nested_list_array_with_tolerance(
+    lhs_type: pl.DataType, rhs_type: pl.DataType
+) -> None:
+    # Arrange
+    lhs = pl.DataFrame(
+        {
+            "pk": [1, 2, 3],
+            "a_left": [
+                [[1.0, 1.1], [2.0, 2.1]],
+                [[3.0, 3.0], [4.0, 4.0]],
+                [[5.0, 5.0], [6.0, 6.0]],
+            ],
+        },
+        schema={"pk": pl.Int64, "a_left": lhs_type},
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1, 2, 3],
+            "a_right": [
+                [[1.0, 1.1], [2.0, 2.1]],
+                [[3.0, 3.0], [4.0, 4.4]],
+                [[5.0, 5.0], [6.0, 6.8]],
+            ],
+        },
+        schema={"pk": pl.Int64, "a_right": rhs_type},
+    )
+
+    # Act
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                abs_tol=0.5,
+                rel_tol=0,
+                max_list_length=2,
+            )
+        )
+        .to_series()
+    )
+
+    assert actual.to_list() == [True, True, False]
+
+
 def test_condition_equal_columns_nested_dtype_mismatch() -> None:
     # Arrange
     lhs = pl.DataFrame(

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -231,17 +231,17 @@ def test_condition_equal_columns_temporal_tolerance() -> None:
     assert actual.to_list() == [True, False, False, True]
 
 
-def test_condition_equal_columns_list_different_lengths() -> None:
+def test_condition_equal_columns_two_lists() -> None:
     lhs = pl.DataFrame(
         {
-            "pk": [1, 2],
-            "a_left": [[1.0, 2.0], [3.0]],
+            "pk": [1, 2, 3, 4, 5],
+            "a_left": [[1.0, 2.0], [3.0], [5.0, None], None, None],
         },
     )
     rhs = pl.DataFrame(
         {
-            "pk": [1, 2],
-            "a_right": [[1.0, 2.0], [3.0, 4.0]],
+            "pk": [1, 2, 3, 4, 5],
+            "a_right": [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0], None],
         },
     )
 
@@ -259,36 +259,7 @@ def test_condition_equal_columns_list_different_lengths() -> None:
         )
         .to_series()
     )
-    assert actual.to_list() == [True, False]
-
-
-def test_condition_equal_columns_list_nulls() -> None:
-    lhs = pl.DataFrame(
-        {
-            "pk": [1, 2, 3],
-            "a_left": [[1.0, 2.0], None, None],
-        },
-    )
-    rhs = pl.DataFrame(
-        {
-            "pk": [1, 2, 3],
-            "a_right": [[1.0, 2.0], [3.0], None],
-        },
-    )
-
-    actual = (
-        lhs.join(rhs, on="pk", maintain_order="left")
-        .select(
-            condition_equal_columns(
-                "a",
-                dtype_left=lhs.schema["a_left"],
-                dtype_right=rhs.schema["a_right"],
-                max_list_length=2,
-            )
-        )
-        .to_series()
-    )
-    assert actual.to_list() == [True, False, True]
+    assert actual.to_list() == [True, False, False, False, True]
 
 
 def test_condition_equal_columns_array_vs_list_length_mismatch() -> None:
@@ -323,7 +294,7 @@ def test_condition_equal_columns_array_vs_list_length_mismatch() -> None:
     assert actual.to_list() == [True, False]
 
 
-def test_condition_equal_columns_array_different_shapes() -> None:
+def test_condition_equal_columns_two_arrays_different_shapes() -> None:
     lhs = pl.DataFrame(
         {
             "pk": [1],

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -81,7 +81,7 @@ def test_condition_equal_columns_different_struct_fields() -> None:
 @pytest.mark.parametrize(
     "rhs_type", [pl.Array(pl.Float64, shape=2), pl.List(pl.Float64)]
 )
-def test_condition_equal_columns_list_array_equal_exact(
+def test_condition_equal_columns_list_array_with_tolerance(
     lhs_type: pl.DataType, rhs_type: pl.DataType
 ) -> None:
     # Arrange
@@ -110,12 +110,58 @@ def test_condition_equal_columns_list_array_equal_exact(
                 dtype_right=rhs.schema["a_right"],
                 abs_tol=0.5,
                 rel_tol=0,
+                max_list_length=2,
             )
         )
         .to_series()
     )
 
-    # Assert
+    # Assert: diff is 0.1, within abs_tol=0.5
+    assert actual.to_list() == [True, True]
+
+
+@pytest.mark.parametrize(
+    "lhs_type", [pl.Array(pl.Float64, shape=2), pl.List(pl.Float64)]
+)
+@pytest.mark.parametrize(
+    "rhs_type", [pl.Array(pl.Float64, shape=2), pl.List(pl.Float64)]
+)
+def test_condition_equal_columns_list_array_exceeds_tolerance(
+    lhs_type: pl.DataType, rhs_type: pl.DataType
+) -> None:
+    # Arrange
+    lhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_left": [[1.0, 1.1], [2.0, 2.1]],
+        },
+        schema={"pk": pl.Int64, "a_left": lhs_type},
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_right": [[1.0, 1.1], [2.0, 2.8]],
+        },
+        schema={"pk": pl.Int64, "a_right": rhs_type},
+    )
+
+    # Act
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                abs_tol=0.5,
+                rel_tol=0,
+                max_list_length=2,
+            )
+        )
+        .to_series()
+    )
+
+    # Assert: diff is 0.7, exceeds abs_tol=0.5
     assert actual.to_list() == [True, False]
 
 
@@ -224,6 +270,97 @@ def test_condition_equal_columns_temporal_tolerance() -> None:
 
     # Assert
     assert actual.to_list() == [True, False, False, True]
+
+
+def test_condition_equal_columns_list_different_lengths() -> None:
+    lhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_left": [[1.0, 2.0], [3.0]],
+        },
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_right": [[1.0, 2.0], [3.0, 4.0]],
+        },
+    )
+
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                abs_tol=0.5,
+                rel_tol=0,
+                max_list_length=2,
+            )
+        )
+        .to_series()
+    )
+    assert actual.to_list() == [True, False]
+
+
+def test_condition_equal_columns_list_nulls() -> None:
+    lhs = pl.DataFrame(
+        {
+            "pk": [1, 2, 3],
+            "a_left": [[1.0, 2.0], None, None],
+        },
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1, 2, 3],
+            "a_right": [[1.0, 2.0], [3.0], None],
+        },
+    )
+
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                max_list_length=2,
+            )
+        )
+        .to_series()
+    )
+    assert actual.to_list() == [True, False, True]
+
+
+def test_condition_equal_columns_array_vs_list_length_mismatch() -> None:
+    lhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_left": [[1.0, 2.0], [3.0, 4.0]],
+        },
+        schema={"pk": pl.Int64, "a_left": pl.Array(pl.Float64, shape=2)},
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_right": [[1.0, 2.0], [3.0]],
+        },
+    )
+
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                abs_tol=0.5,
+                rel_tol=0,
+            )
+        )
+        .to_series()
+    )
+    assert actual.to_list() == [True, False]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -32,7 +32,7 @@ def test_condition_equal_columns_struct() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
-                max_list_length=0,
+                max_list_length=None,
                 abs_tol=0.5,
                 rel_tol=0,
             )
@@ -67,7 +67,7 @@ def test_condition_equal_columns_different_struct_fields() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
-                max_list_length=0,
+                max_list_length=None,
             )
         )
         .to_series()
@@ -89,15 +89,15 @@ def test_condition_equal_columns_list_array_with_tolerance(
     # Arrange
     lhs = pl.DataFrame(
         {
-            "pk": [1, 2],
-            "a_left": [[1.0, 1.1], [2.0, 2.1]],
+            "pk": [1, 2, 3],
+            "a_left": [[1.0, 1.1], [2.0, 2.1], [3.0, 3.0]],
         },
         schema={"pk": pl.Int64, "a_left": lhs_type},
     )
     rhs = pl.DataFrame(
         {
-            "pk": [1, 2],
-            "a_right": [[1.0, 1.1], [2.0, 2.2]],
+            "pk": [1, 2, 3],
+            "a_right": [[1.0, 1.1], [2.0, 2.2], [3.0, 3.7]],
         },
         schema={"pk": pl.Int64, "a_right": rhs_type},
     )
@@ -118,53 +118,7 @@ def test_condition_equal_columns_list_array_with_tolerance(
         .to_series()
     )
 
-    # Assert: diff is 0.1, within abs_tol=0.5
-    assert actual.to_list() == [True, True]
-
-
-@pytest.mark.parametrize(
-    "lhs_type", [pl.Array(pl.Float64, shape=2), pl.List(pl.Float64)]
-)
-@pytest.mark.parametrize(
-    "rhs_type", [pl.Array(pl.Float64, shape=2), pl.List(pl.Float64)]
-)
-def test_condition_equal_columns_list_array_exceeds_tolerance(
-    lhs_type: pl.DataType, rhs_type: pl.DataType
-) -> None:
-    # Arrange
-    lhs = pl.DataFrame(
-        {
-            "pk": [1, 2],
-            "a_left": [[1.0, 1.1], [2.0, 2.1]],
-        },
-        schema={"pk": pl.Int64, "a_left": lhs_type},
-    )
-    rhs = pl.DataFrame(
-        {
-            "pk": [1, 2],
-            "a_right": [[1.0, 1.1], [2.0, 2.8]],
-        },
-        schema={"pk": pl.Int64, "a_right": rhs_type},
-    )
-
-    # Act
-    actual = (
-        lhs.join(rhs, on="pk", maintain_order="left")
-        .select(
-            condition_equal_columns(
-                "a",
-                dtype_left=lhs.schema["a_left"],
-                dtype_right=rhs.schema["a_right"],
-                abs_tol=0.5,
-                rel_tol=0,
-                max_list_length=2,
-            )
-        )
-        .to_series()
-    )
-
-    # Assert: diff is 0.7, exceeds abs_tol=0.5
-    assert actual.to_list() == [True, False]
+    assert actual.to_list() == [True, True, False]
 
 
 def test_condition_equal_columns_nested_dtype_mismatch() -> None:
@@ -190,7 +144,7 @@ def test_condition_equal_columns_nested_dtype_mismatch() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
-                max_list_length=0,
+                max_list_length=None,
             )
         )
         .to_series()
@@ -223,7 +177,7 @@ def test_condition_equal_columns_exactly_one_nested() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
-                max_list_length=0,
+                max_list_length=None,
             )
         )
         .to_series()
@@ -266,7 +220,7 @@ def test_condition_equal_columns_temporal_tolerance() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
-                max_list_length=0,
+                max_list_length=None,
                 abs_tol_temporal=dt.timedelta(seconds=2),
             )
         )
@@ -359,7 +313,7 @@ def test_condition_equal_columns_array_vs_list_length_mismatch() -> None:
                 "a",
                 dtype_left=lhs.schema["a_left"],
                 dtype_right=rhs.schema["a_right"],
-                max_list_length=0,
+                max_list_length=None,
                 abs_tol=0.5,
                 rel_tol=0,
             )
@@ -367,6 +321,99 @@ def test_condition_equal_columns_array_vs_list_length_mismatch() -> None:
         .to_series()
     )
     assert actual.to_list() == [True, False]
+
+
+def test_condition_equal_columns_array_different_shapes() -> None:
+    lhs = pl.DataFrame(
+        {
+            "pk": [1],
+            "a_left": [[1.0, 2.0]],
+        },
+        schema={"pk": pl.Int64, "a_left": pl.Array(pl.Float64, shape=2)},
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1],
+            "a_right": [[1.0, 2.0, 3.0]],
+        },
+        schema={"pk": pl.Int64, "a_right": pl.Array(pl.Float64, shape=3)},
+    )
+
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                max_list_length=None,
+            )
+        )
+        .to_series()
+    )
+    assert actual.to_list() == [False]
+
+
+def test_condition_equal_columns_empty_arrays() -> None:
+    lhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_left": [[], None],
+        },
+        schema={"pk": pl.Int64, "a_left": pl.Array(pl.Float64, shape=0)},
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1, 2],
+            "a_right": [[], None],
+        },
+        schema={"pk": pl.Int64, "a_right": pl.Array(pl.Float64, shape=0)},
+    )
+
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                max_list_length=None,
+            )
+        )
+        .to_series()
+    )
+    assert actual.to_list() == [True, True]
+
+
+def test_condition_equal_columns_empty_lists() -> None:
+    lhs = pl.DataFrame(
+        {
+            "pk": [1, 2, 3],
+            "a_left": [[], None, []],
+        },
+        schema={"pk": pl.Int64, "a_left": pl.List(pl.Float64)},
+    )
+    rhs = pl.DataFrame(
+        {
+            "pk": [1, 2, 3],
+            "a_right": [[], None, None],
+        },
+        schema={"pk": pl.Int64, "a_right": pl.List(pl.Float64)},
+    )
+
+    actual = (
+        lhs.join(rhs, on="pk", maintain_order="left")
+        .select(
+            condition_equal_columns(
+                "a",
+                dtype_left=lhs.schema["a_left"],
+                dtype_right=rhs.schema["a_right"],
+                max_list_length=0,
+            )
+        )
+        .to_series()
+    )
+    assert actual.to_list() == [True, True, False]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Motivation

Partially addresses #8. Sequences (lists and arrays) are compared element-wise, iterating over each position in the sequence. Each element is then compared using the standard type-aware logic, so absolute/relative float tolerances and absolute temporal tolerances all apply naturally.

### Maximum sequence length
An array's length (or shape for multi-dimensional arrays) is known statically from its data type. When at least one of the two compared columns is an array, its length determines the number of elements to compare. When both columns are lists, the maximum list length must be computed at runtime — this is handled by the cached property `_max_list_lengths_by_column`, a dictionary mapping column names to their maximum list length, populated only for columns that are `pl.List` in both data frames. The resolved `max_list_length: int | None` is then passed to `condition_equal_columns()`.

### Sequences of different lengths
Arrays have a fixed length, so comparing two arrays of different shapes can immediately return `False`. In all other cases, lengths may vary row-by-row, which is captured in the has_same_length expression. To avoid out-of-bound errors when indexing into shorter lists, `null_on_oob=True` is used instead of raising. The final result combines `has_same_length` with `elements_match` (the element-wise comparison), so rows with mismatched lengths are marked as unequal.

### Multi-dimensional sequences
Nested sequences (e.g., lists of lists or multi-dimensional arrays) are handled recursively: outer elements are extracted positionally, then compared via the same `_compare_columns` logic until primitive types are reached. When both sides are lists at an inner nesting level, no `max_list_length` is available, so the comparison falls back to direct equality without element-wise unrolling (i.e., tolerances do not apply at inner list levels).

<!-- Why is this change necessary? Link issues here if applicable. -->

# Changes

- add cached property `_max_list_lengths_by_column: dict[str, int]`
- introduce function `_compare_sequence_columns()` to compare lists and arrays with each other
- add extensive test coverage
  - Modify `test_condition_equal_columns_list_array_{equal_exact -> with_tolerance}` to reflect the updated logic
  - Build on the former test with nested sequence types in `test_condition_equal_columns_nested_list_array_with_tolerance`
  - test comparison of two list columns in `test_condition_equal_columns_two_lists`, including empty lists, lists with `None` and `None`
  - cover mismatches of lengths in `test_condition_equal_columns_array_vs_list_length_mismatch`
  - cover mismatching array shapes in `test_condition_equal_columns_two_arrays_different_shapes`
  - handle the edge case of empty arrays and lists in `test_condition_equal_columns_empty_arrays` and `test_condition_equal_columns_empty_lists`, respectively

<!-- What changes have been performed? -->
