### PR TITLE
ci: Fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: mambaforge-latest
   commands:


### PR DESCRIPTION
# Motivation

It fails in #43 and #44, the current `os` is no longer supported (see [here](https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-os))

# Changes

- Replace deprecated `os`
