### PR TITLE
refactor: Do not emit any warnings in tests and treat warnings in tests as errors

### DIFF
--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -728,7 +728,7 @@ class DataFrameComparison:
             return False
 
         return (
-            pl.concat([left, right], how="horizontal")
+            pl.concat([left, right], how="horizontal_extend")
             .select(
                 condition_equal_rows(
                     columns=common_columns,
@@ -1246,9 +1246,12 @@ def _list_length_exprs(
     """Collect max-list-length scalar expressions for every List level in the type
     tree."""
     if isinstance(dtype, pl.List):
-        return [expr.list.len().max(), *_list_length_exprs(expr.explode(), dtype.inner)]
+        return [
+            expr.list.len().max(),
+            *_list_length_exprs(expr.explode(empty_as_null=True), dtype.inner),
+        ]
     if isinstance(dtype, pl.Array):
-        return _list_length_exprs(expr.explode(), dtype.inner)
+        return _list_length_exprs(expr.explode(empty_as_null=True), dtype.inner)
     if isinstance(dtype, pl.Struct):
         return [
             e

--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -728,7 +728,7 @@ class DataFrameComparison:
             return False
 
         return (
-            pl.concat([left, right], how="horizontal_extend")
+            pl.concat([left, right], how="horizontal", strict=True)
             .select(
                 condition_equal_rows(
                     columns=common_columns,

--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -728,7 +728,7 @@ class DataFrameComparison:
             return False
 
         return (
-            pl.concat([left, right], how="horizontal", strict=True)
+            pl.concat([left, right], how="horizontal")
             .select(
                 condition_equal_rows(
                     columns=common_columns,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,4 +96,8 @@ default.extend-ignore-re = [
 addopts = "--import-mode=importlib -m 'not generate'"
 markers = ["generate: mark a test function as generating fixture output."]
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = [
+  "error",
+  # polars' deprecation warning for horizontal concatenation cannot be solved, we are already using it correctly
+  "ignore:the default behavior of `how='horizontal'` for `concat` is deprecated:DeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,4 @@ default.extend-ignore-re = [
 addopts = "--import-mode=importlib -m 'not generate'"
 markers = ["generate: mark a test function as generating fixture output."]
 testpaths = ["tests"]
+filterwarnings = ["error"]

--- a/tests/test_fraction_same.py
+++ b/tests/test_fraction_same.py
@@ -30,20 +30,24 @@ def test_missing_primary_key_fraction_same() -> None:
 @pytest.mark.parametrize("frame_type", FRAME_TYPES)
 @pytest.mark.parametrize(
     "dtypes_left",
-    itertools.zip_longest(
-        FLOAT_DTYPES,
-        SIGNED_INTEGER_DTYPES,
-        UNSIGNED_INTEGER_DTYPES,
-        fillvalue=pl.Float32,
+    list(
+        itertools.zip_longest(
+            FLOAT_DTYPES,
+            SIGNED_INTEGER_DTYPES,
+            UNSIGNED_INTEGER_DTYPES,
+            fillvalue=pl.Float32,
+        )
     ),
 )
 @pytest.mark.parametrize(
     "dtypes_right",
-    itertools.zip_longest(
-        FLOAT_DTYPES,
-        SIGNED_INTEGER_DTYPES,
-        UNSIGNED_INTEGER_DTYPES,
-        fillvalue=pl.Float32,
+    list(
+        itertools.zip_longest(
+            FLOAT_DTYPES,
+            SIGNED_INTEGER_DTYPES,
+            UNSIGNED_INTEGER_DTYPES,
+            fillvalue=pl.Float32,
+        )
     ),
 )
 @pytest.mark.parametrize("parallel", [True, False])


### PR DESCRIPTION
# Motivation

Currently, we emit warnings from package code in new polars versions. I think we should not (e.g., as consumers might treat them as errors)

# Changes

- Treat warnings as errors, with one exception
- Fix code