### PR TITLE
chore: Raise on primary key dtype mimsatch

### DIFF
--- a/diffly/comparison.py
+++ b/diffly/comparison.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Literal, Self, overload
@@ -165,18 +164,14 @@ class DataFrameComparison:
                     "The columns are not a primary key for the right data frame."
                 )
 
-            # Try joining empty frames to check if the primary key columns are
-            # compatible. If not, we set the primary key to `None` and emit an
-            # appropriate warning.
+            # Check that the primary key dtypes are compatible for joining.
             try:
                 left_schema.to_frame().join(right_schema.to_frame(), on=primary_key)
             except pl.exceptions.SchemaError as e:
-                warnings.warn(
-                    "`primary_key` is set to None as the primary key of the left and "
-                    "right tables have incompatible data types: "
-                    + str(e).split("\n")[0],
-                )
-                primary_key = None
+                raise PrimaryKeyError(
+                    "Primary key columns have incompatible dtypes between left and "
+                    "right: " + str(e).split("\n")[0]
+                ) from e
 
         # Assign other relevant attributes
         schemas = Schemas(left_schema, right_schema)

--- a/tests/test_dataframe_comparison.py
+++ b/tests/test_dataframe_comparison.py
@@ -45,13 +45,12 @@ def test_pk_violation() -> None:
 
 
 def test_incompatible_primary_key_dtypes() -> None:
-    with pytest.warns(UserWarning, match=".*datatypes of join keys don't match.*"):
-        comparison = compare_frames(
+    with pytest.raises(PrimaryKeyError, match="incompatible dtypes"):
+        compare_frames(
             pl.DataFrame({"key": ["tiger"], "speed_kph": [5.0]}),
             pl.DataFrame({"key": [1], "speed_kph": [5.0]}),
             primary_key=["key"],
         )
-    comparison.summary()
 
 
 def test_incomplete_mapping() -> None:


### PR DESCRIPTION
# Motivation

Solves #52.

<!-- Why is this change necessary? Link issues here if applicable. -->

# Changes

Instead of silently ignoring an invalid primary key (e.g. due to data type mismatch), I suggest raising a `PrimaryKeyError` as we do for other instances where the passed `primary_key` is in fact not a valid primary key.

<!-- What changes have been performed? -->
