### PR TITLE
chore: Add `pull_request` trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 # Automatically stop old builds on the same branch/PR
 concurrency:


### PR DESCRIPTION
# Motivation

The CI workflow doesn't run on PRs from forks such as in #58. I'd like to change the trigger so that it runs on PRs and pushed to `main`. It will no longer run on pushed to non-main branches without PRs.

<!-- Why is this change necessary? Link issues here if applicable. -->

# Changes

<!-- What changes have been performed? -->
